### PR TITLE
Adds express charset advisory

### DIFF
--- a/advisories/express-no-charset-in-content-type-header.md
+++ b/advisories/express-no-charset-in-content-type-header.md
@@ -3,7 +3,7 @@ title: express No Charset in Content-Type Header
 author: Paweł Hałdrzyński
 module_name: express
 publish_date: Fri Sep 12 2014 07:46:45 GMT-0700 (PDT)
-cves: "[]"
+cves: "[{\"name\":\"CVE-2014-6393\",\"link\":\"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6393\"}]"
 vulnerable_versions: "< 3.11.0, < 4.5.0"
 patched_versions: ">= 3.11.0, >= 4.5.0"
 ---

--- a/advisories/express-no-charset-in-content-type-header.md
+++ b/advisories/express-no-charset-in-content-type-header.md
@@ -1,0 +1,15 @@
+---
+title: express No Charset in Content-Type Header
+author: Paweł Hałdrzyński
+module_name: express
+publish_date: Fri Sep 12 2014 07:46:45 GMT-0700 (PDT)
+cves: "[]"
+vulnerable_versions: "< 3.8.0, < 4.3.0"
+patched_versions: ">= 3.8.0, >= 4.3.0"
+---
+
+## Overview
+Vulnerable versions of express do not specify a charset field in the content-type heade while displaying 400 level response messages. The lack of enforcing user's browser to set correct charset, could be leveraged by an attacker to perform a cross-site scripting attack, using non-standard encodings, like UTF-7.
+
+## Recommendation
+Update express to a patched version.

--- a/advisories/express-no-charset-in-content-type-header.md
+++ b/advisories/express-no-charset-in-content-type-header.md
@@ -4,8 +4,8 @@ author: Paweł Hałdrzyński
 module_name: express
 publish_date: Fri Sep 12 2014 07:46:45 GMT-0700 (PDT)
 cves: "[]"
-vulnerable_versions: "< 3.8.0, < 4.3.0"
-patched_versions: ">= 3.8.0, >= 4.3.0"
+vulnerable_versions: "< 3.11.0, < 4.5.0"
+patched_versions: ">= 3.11.0, >= 4.5.0"
 ---
 
 ## Overview


### PR DESCRIPTION
How does nsp handle stuff like "< 3.8.0, < 4.3.0" @evilpacket 