### PR TITLE
Add utf-8 meta charset to the layout template

### DIFF
--- a/views/layout.jade
+++ b/views/layout.jade
@@ -1,6 +1,7 @@
 doctype html
 html
     head
+        meta(charset='utf-8')
         title Node Security Project | #{title}
         meta(name='viewport', content='width=device-width,initial-scale=1.0')
         link(rel='stylesheet', href='//maxcdn.bootstrapcdn.com/bootstrap/2.3.1/css/bootstrap.min.css')


### PR DESCRIPTION
It fixes issue #37.

I added `meta(charset='utf-8')` to the Jade template - which results in `<meta charset="utf-8">` in HTML - to fix the "™" character not displaying correctly, and also to make sure that the charset will not be guessed as UTF-7 in old browsers (see: [UTF-7 encoding](https://www.owasp.org/index.php/XSS_Filter_Evasion_Cheat_Sheet#UTF-7_encoding) on [The Open Web Application Security Project](https://www.owasp.org/index.php/Main_Page) and [UTF-7 XSS Cheat Sheet](http://openmya.hacker.jp/hasegawa/security/utf7cs.html) by @hasegawayosuke).

### Website - Before:
![charset-before](https://cloud.githubusercontent.com/assets/119231/6679697/1ba16f7a-cc4c-11e4-950e-00ed2006c047.png)
### Website - After:
![charset-after](https://cloud.githubusercontent.com/assets/119231/6679698/1fc91436-cc4c-11e4-99d7-bd25d5fa07c3.png)

### HTML - Before:
```
$ curl -is http://localhost:3000/ | less
HTTP/1.1 200 OK
cache-control: no-cache
content-type: text/html
content-length: 3450
accept-ranges: bytes
Date: Tue, 17 Mar 2015 00:51:47 GMT
Connection: keep-alive

<!DOCTYPE html><html><head><title>Node Security Project ...
```
### HTML - After:
```
$ curl -is http://localhost:3000/ | less
HTTP/1.1 200 OK
cache-control: no-cache
content-type: text/html
content-length: 3472
accept-ranges: bytes
Date: Tue, 17 Mar 2015 00:52:47 GMT
Connection: keep-alive

<!DOCTYPE html><html><head><meta charset="utf-8"><title>Node Security Project ...
```