### PR TITLE
Fix grunt-nsp-package title on Tools page

### DIFF
--- a/views/tools.jade
+++ b/views/tools.jade
@@ -24,10 +24,10 @@ block content
           code nsp package
 
       section
-        h3 grunt-nsp-package
+        h3 grunt-nsp-shrinkwrap
 
       section
-        h3 grunt-nsp-shrinkwrap
+        h3 grunt-nsp-package
         p Grunt task that audits your package.json file against the nodesecurity.io API for validation that dependencies or dependencies of dependencies are not vulnerable to known vulnerabilities.
         h4 Installation
         pre


### PR DESCRIPTION
The [grunt-nsp-shrinkwrap](https://www.npmjs.com/package/grunt-nsp-shrinkwrap) section was showing info for [grunt-nsp-package](https://www.npmjs.com/package/grunt-nsp-package). I just switched the titles around.