### PR TITLE
Add gulp-nsp to Tools page

### DIFF
--- a/views/tools.jade
+++ b/views/tools.jade
@@ -56,3 +56,24 @@ block content
             | >> qs         0.5.1          >= 1.x        express > connect      See website
             | Warning: known vulnerable modules found Use --force to continue.<br />
             | Aborted due to warnings.
+
+      section
+        h3 gulp-nsp
+        p A gulp plugin that runs the Node Security Project audit on your package.json or npm-shrinkwrap.json
+        h4 Installation
+        pre
+          code npm install gulp-nsp --save
+        p Then in your gulpfile, add the following task like so.
+        pre
+          code
+            | var gulpNSP = require('gulp-nsp');
+            | 
+            | //To check your package.json
+            | gulp.task('nsp', function (cb) {
+            |   gulpNSP('./package.json', cb);
+            | });
+            | 
+            | //To check your shrinkwrap.json
+            | gulp.task('nsp', function (cb) {
+            |   gulpNSP('./npm-shrinkwrap.json', cb);
+            | });


### PR DESCRIPTION
Basically copy pasted the README from [gulp-nsp](https://github.com/nodesecurity/gulp-nsp), but it seems like a useful tool to spread information about. Do note the whitespace after the pipe `| ` otherwise Jade gets sad.

Oh, and check https://github.com/nodesecurity/gulp-nsp/issues/6 if you can. It still says "prototype" in the description of `gulp-nsp`.